### PR TITLE
[TASK] Port to Thin Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ features = ["cguid", "commapi", "errhandlingapi", "fileapi", "guiddef", "handlea
 IOKit-sys = "0.1"
 mach = "0.2"
 CoreFoundation-sys = "0.1.3"
+
+[features]
+thin_client = []

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -845,7 +845,8 @@ fn udev_hex_property_as_u16(d: &libudev::Device, key: &str) -> ::Result<u16> {
     }
 }
 
-// FIXME: this hack is only to simulate Bluegiga device on Thin Client NOT to be used in production! 
+// FIXME: this workaround should be used only as long as the Thin Client udev library does not expose 
+// properties to detect the Bluegiga dongle. 
 #[cfg(all(feature = "thin_client", target_os = "linux", not(target_env = "musl")))]
 fn port_type(d: &libudev::Device) -> ::Result<::SerialPortType> {
     println!("device properties:");


### PR DESCRIPTION
Add compile time flag for tty.rs to assume a device under /dev/ttyACM0
is a Bluegiga Dongle if running on a 32-bit Linux.
At this time, Thin Client udev library does not expose enough parameters
for tty.rs to recognize Bluegiga Dongle.
The purpose of this change is to allow creating a testable build running
on Thin Client.